### PR TITLE
Initialize commons-services project structure and configuration files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - develop
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The workflow will now also run on pushes to the `develop` branch, in addition to the existing `main` branch.